### PR TITLE
카드 삭제시 타이틀뷰의 카드 카운트 변경되도록 구현

### DIFF
--- a/TodoApp/TodoApp/Controllers/TasksViewController.swift
+++ b/TodoApp/TodoApp/Controllers/TasksViewController.swift
@@ -15,17 +15,29 @@ class TasksViewController: UIViewController, TitleViewDelegate {
     var tasksDataSource: TasksTableViewDataSource!
     var tasksDelegate = TasksTableViewDelegate()
     
+    let childID: Int
+    
     var category: Category? {
         didSet {
             configureData()
             configureDataSource()
         }
     }
+    
+    init(childID: Int, nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        self.childID = childID
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         titleView.delegate = self
         tableView.delegate = tasksDelegate
-
+        
         self.view.addSubview(titleView)
         self.view.addSubview(tableView)
         self.tableView.register(TasksTableViewCell.self, forCellReuseIdentifier: "tasksCell")
@@ -54,9 +66,11 @@ class TasksViewController: UIViewController, TitleViewDelegate {
     
     func configureDataSource() {
         guard let category = category else { return }
-        tasksDataSource = TasksTableViewDataSource(tasks: category.tasks)
-        tableView.dataSource = tasksDataSource
-        tableView.reloadData()
+
+            tasksDataSource = TasksTableViewDataSource(tasksID: childID, tasks: category.tasks)
+                       tableView.dataSource = tasksDataSource
+                       tableView.reloadData()
+        
     }
     
     func popNewCardView() {
@@ -64,3 +78,4 @@ class TasksViewController: UIViewController, TitleViewDelegate {
         self.present(newCardViewController, animated: true, completion: nil)
     }
 }
+

--- a/TodoApp/TodoApp/Controllers/ViewController.swift
+++ b/TodoApp/TodoApp/Controllers/ViewController.swift
@@ -9,12 +9,12 @@
 import UIKit
 
 class ViewController: UIViewController {
-    
-    
     @IBOutlet var navigationBar: UINavigationBar!
-    let firstViewController = TasksViewController()
-    let secondViewController = TasksViewController()
-    let thirdViewController = TasksViewController()
+    let firstViewController = TasksViewController(childID: 0, nibName: nil, bundle: nil)
+    let secondViewController = TasksViewController(childID: 1, nibName: nil, bundle: nil)
+    let thirdViewController = TasksViewController(childID: 2, nibName: nil, bundle: nil)
+    
+    lazy var controllers = [firstViewController, secondViewController, thirdViewController]
     
     private var firstView: UIView?
     private var secondView: UIView?
@@ -31,6 +31,7 @@ class ViewController: UIViewController {
         setConstraints()
         
         requestAllData()
+        addNotification()
     }
     
     func addChild() {
@@ -90,6 +91,21 @@ class ViewController: UIViewController {
         }
     }
     
+    func addNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(updateData(_:)), name: .updateCount, object: nil)
+    }
     
+    @objc func updateData(_ notification: Notification) {
+        guard let updateInfo = notification.userInfo?["updateInfo"] as? (count: Int, tasksID: Int) else { return }
+        for controller in controllers {
+            if controller.childID == updateInfo.tasksID {
+                controller.titleView.setTasksCount(count: updateInfo.count)
+            }
+        }
+        
+    }
 }
 
+extension Notification.Name {
+    static let updateCount = Notification.Name(rawValue: "updateTitle")
+}

--- a/TodoApp/TodoApp/DataSource/TasksTableViewDataSource.swift
+++ b/TodoApp/TodoApp/DataSource/TasksTableViewDataSource.swift
@@ -11,9 +11,15 @@ import UIKit
 class TasksTableViewDataSource: NSObject, UITableViewDataSource {
 
     static let identifier = "tasksCell"
-    var tasks: [Contents]
+    let tasksID: Int
+    var tasks: [Contents] {
+        didSet {
+            NotificationCenter.default.post(name: .updateCount , object: tasks, userInfo: ["updateInfo":(count: tasks.count, tasksID: tasksID)])
+        }
+    }
     
-    init(tasks: [Contents]) {
+    init(tasksID: Int, tasks: [Contents]) {
+        self.tasksID = tasksID
         self.tasks = tasks
     }
 
@@ -38,6 +44,10 @@ class TasksTableViewDataSource: NSObject, UITableViewDataSource {
             tableView.deleteRows(at: [indexPath], with: .automatic)
             tableView.endUpdates()
         }
+    }
+    
+    func updateTasksCount(handler: (Int) -> ()) {
+        
     }
 
 }

--- a/TodoApp/TodoApp/Models/Tasks.swift
+++ b/TodoApp/TodoApp/Models/Tasks.swift
@@ -11,16 +11,14 @@ import Foundation
 struct Tasks: Codable {
     var status: Bool
     var data: [Category]
-    
-   
 }
+
 struct Category: Codable {
        var id: Int
        var name: String
        var tasks: [Contents]
-       
-       
-   }
+}
+
 struct Contents: Codable {
     var title: String
     var content: String

--- a/TodoApp/TodoApp/Views/View/TitleView.swift
+++ b/TodoApp/TodoApp/Views/View/TitleView.swift
@@ -85,7 +85,7 @@ class TitleView: UIView {
     func setTitle(title: String) {
         tasksTitle.text = title
     }
-    
+
     @objc private func popNewCardView() {
         delegate?.popNewCardView()
     }


### PR DESCRIPTION
카드 삭제시 타이틀 뷰의 카드 카운트가 변경되도록 Notification을 이용해 구현했습니다.
각각의 뷰 컨트롤러를 구분해주기 위해 차일드 뷰컨트롤러인 TasksViewController에 childID라는 변수와,
TasksViewDataSource에 tasksID라는 변수를 추가해서 해당 변수로 서로를 구분하고,
변경된 tasksID를 노티로 전달해 동일한 id를 가진 뷰컨트롤러의 값이 변경되도록 했습니다.
각각을 구분하기 위해 이런 방식을 사용했는데 개선할 수 있을 것 같으나 좋은 생각이 마땅히 떠오르지 않습니다ㅠ